### PR TITLE
Decode small byte array

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Use the [Nimble][2] package manager to add `ethers` to an existing
 project. Add the following to its .nimble file:
 
 ```nim
-requires "https://github.com/status-im/nim-ethers >= 0.1.2 & < 0.2.0"
+requires "https://github.com/status-im/nim-ethers >= 0.1.3 & < 0.2.0"
 ```
 
 Usage

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -1,4 +1,4 @@
-version = "0.1.2"
+version = "0.1.3"
 author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"

--- a/ethers/events.nim
+++ b/ethers/events.nim
@@ -8,6 +8,17 @@ type
   ValueType = uint8 | uint16 | uint32 | uint64 | UInt256 | UInt128 |
               int8 | int16 | int32 | int64 | Int256 | Int128 |
               bool | Address
+  SmallByteArray = array[ 1, byte] | array[ 2, byte] | array[ 3, byte] |
+                   array[ 4, byte] | array[ 5, byte] | array[ 6, byte] |
+                   array[ 7, byte] | array[ 8, byte] | array[ 9, byte] |
+                   array[10, byte] | array[11, byte] | array[12, byte] |
+                   array[13, byte] | array[14, byte] | array[15, byte] |
+                   array[16, byte] | array[17, byte] | array[18, byte] |
+                   array[19, byte] | array[20, byte] | array[21, byte] |
+                   array[22, byte] | array[23, byte] | array[24, byte] |
+                   array[25, byte] | array[26, byte] | array[27, byte] |
+                   array[28, byte] | array[29, byte] | array[30, byte] |
+                   array[31, byte] | array[32, byte]
 
 push: {.upraises: [].}
 
@@ -27,7 +38,7 @@ func decode*[E: Event](_: type E, data: seq[byte], topics: seq[Topic]): ?!E =
     if field.hasCustomPragma(indexed):
       if i >= topics.len:
         return failure "indexed event parameter not found"
-      if typeof(field) is ValueType:
+      if typeof(field) is ValueType or typeof(field) is SmallByteArray:
         field = ?AbiDecoder.decode(@(topics[i]), typeof(field))
       inc i
   success event

--- a/testmodule/testEvents.nim
+++ b/testmodule/testEvents.nim
@@ -14,12 +14,14 @@ suite "Events":
       b {.indexed.}: Address
       c: Address
       d {.indexed.}: UInt256
+      e {.indexed.}: array[32, byte]
     ComplexIndexedEvent = object of Event
       a {.indexed.}: array[42, UInt256]
       b {.indexed.}: seq[UInt256]
       c {.indexed.}: string
       d {.indexed.}: seq[byte]
       e {.indexed.}: (Address, UInt256)
+      f {.indexed.}: array[33, byte]
 
   proc example(_: type SimpleEvent): SimpleEvent =
     SimpleEvent(
@@ -32,7 +34,8 @@ suite "Events":
       a: UInt256.example,
       b: Address.example,
       c: Address.example,
-      d: UInt256.example
+      d: UInt256.example,
+      e: array[32, byte].example
     )
 
   func encode[T](_: type Topic, value: T): Topic =
@@ -50,6 +53,7 @@ suite "Events":
     topics.add Topic.default
     topics.add Topic.encode(event.b)
     topics.add Topic.encode(event.d)
+    topics.add Topic.encode(event.e)
     let data = AbiEncoder.encode( (event.a, event.c) )
     check IndexedEvent.decode(data, topics) == success event
 
@@ -69,6 +73,7 @@ suite "Events":
   test "ignores indexed complex arguments":
     let topics = @[
       Topic.default,
+      Topic.example,
       Topic.example,
       Topic.example,
       Topic.example,


### PR DESCRIPTION
Byte arrays of size at most 32 are encoded directly into the indexed event arguments.