### PR TITLE
supply block parameter to eth_call, default being BlockTag.latest

### DIFF
--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -56,16 +56,20 @@ proc decodeResponse(T: type, bytes: seq[byte]): T =
     raiseContractError "unable to decode return value as " & $T
   return decoded
 
-proc call(contract: Contract, function: string, parameters: tuple) {.async.} =
+proc call(contract: Contract,
+          function: string,
+          parameters: tuple,
+          blockTag = BlockTag.latest) {.async.} =
   let transaction = createTransaction(contract, function, parameters)
-  discard await contract.provider.call(transaction)
+  discard await contract.provider.call(transaction, blockTag)
 
 proc call(contract: Contract,
           function: string,
           parameters: tuple,
-          ReturnType: type): Future[ReturnType] {.async.} =
+          ReturnType: type,
+          blockTag = BlockTag.latest): Future[ReturnType] {.async.} =
   let transaction = createTransaction(contract, function, parameters)
-  let response = await contract.provider.call(transaction)
+  let response = await contract.provider.call(transaction, blockTag)
   return decodeResponse(ReturnType, response)
 
 proc send(contract: Contract, function: string, parameters: tuple) {.async.} =

--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -30,7 +30,9 @@ method getBlockNumber*(provider: Provider): Future[UInt256] {.base.} =
 method getBlock*(provider: Provider, tag: BlockTag): Future[?Block] {.base.} =
   doAssert false, "not implemented"
 
-method call*(provider: Provider, tx: Transaction): Future[seq[byte]] {.base.} =
+method call*(provider: Provider,
+             tx: Transaction,
+             blockTag = BlockTag.latest): Future[seq[byte]] {.base.} =
   doAssert false, "not implemented"
 
 method getGasPrice*(provider: Provider): Future[UInt256] {.base.} =

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -77,9 +77,10 @@ method getBlock*(provider: JsonRpcProvider,
   return await client.eth_getBlockByNumber(tag, false)
 
 method call*(provider: JsonRpcProvider,
-             tx: Transaction): Future[seq[byte]] {.async.} =
+             tx: Transaction,
+             blockTag = BlockTag.latest): Future[seq[byte]] {.async.} =
   let client = await provider.client
-  return await client.eth_call(tx)
+  return await client.eth_call(tx, blockTag)
 
 method getGasPrice*(provider: JsonRpcProvider): Future[UInt256] {.async.} =
   let client = await provider.client

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -1,7 +1,7 @@
 proc net_version(): string
 proc eth_accounts: seq[Address]
 proc eth_blockNumber: UInt256
-proc eth_call(transaction: Transaction): seq[byte]
+proc eth_call(transaction: Transaction, blockTag: BlockTag): seq[byte]
 proc eth_gasPrice(): UInt256
 proc eth_getBlockByNumber(blockTag: BlockTag, includeTransactions: bool): ?Block
 proc eth_getTransactionCount(address: Address, blockTag: BlockTag): UInt256


### PR DESCRIPTION
Related to https://github.com/status-im/dagger-contracts/issues/9.

When running tests against a contract deployment on a local Go Ethereum test network, I was consistently getting this error for some calls:
```json
{"code": -32602, "message": "missing value for required argument 1"}
```

The problem seemed to be related to this:

https://github.com/ethereum/go-ethereum/issues/2472
https://github.com/ethereum/go-ethereum/pull/2473

For some Ethereum clients/simulators the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter) for `eth_call` is optional, but for Go Ethereum it is not.

The test suite for nim-ethers passes with my changes, and the changes allowed me to move forward with what I was attempting re: https://github.com/status-im/dagger-contracts/issues/9. However, I'm not sure I got it quite right, i.e. it may need some work before it's merge-ready.