### PR TITLE
Fix crash on connect

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Use the [Nimble][2] package manager to add `ethers` to an existing
 project. Add the following to its .nimble file:
 
 ```nim
-requires "https://github.com/status-im/nim-ethers >= 0.1.4 & < 0.2.0"
+requires "https://github.com/status-im/nim-ethers >= 0.1.5 & < 0.2.0"
 ```
 
 Usage

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -1,4 +1,4 @@
-version = "0.1.4"
+version = "0.1.5"
 author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"


### PR DESCRIPTION
Removes `asyncSpawn` in favor of saving a future in `provider.client`, so that any connection errors surface on subsequent calls to the provider, instead of crashing immediately.