### PR TITLE
Subscribe to new blocks

### DIFF
--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -18,6 +18,7 @@ type
     data*: seq[byte]
     topics*: seq[Topic]
   LogHandler* = proc(log: Log) {.gcsafe, upraises:[].}
+  BlockHandler* = proc(blck: Block) {.gcsafe, upraises:[].}
   Topic* = array[32, byte]
   Block* = object
     number*: UInt256
@@ -54,6 +55,11 @@ method getChainId*(provider: Provider): Future[UInt256] {.base.} =
 method subscribe*(provider: Provider,
                   filter: Filter,
                   callback: LogHandler):
+                 Future[Subscription] {.base.} =
+  doAssert false, "not implemented"
+
+method subscribe*(provider: Provider,
+                  callback: BlockHandler):
                  Future[Subscription] {.base.} =
   doAssert false, "not implemented"
 

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -9,5 +9,5 @@ proc eth_estimateGas(transaction: Transaction): UInt256
 proc eth_chainId(): UInt256
 proc eth_sendTransaction(transaction: Transaction): array[32, byte]
 proc eth_sign(account: Address, message: seq[byte]): seq[byte]
-proc eth_subscribe(name: string, filter: ?Filter): JsonNode
+proc eth_subscribe(name: string, filter = Filter.none): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool

--- a/testmodule/testJsonRpcProvider.nim
+++ b/testmodule/testJsonRpcProvider.nim
@@ -39,3 +39,14 @@ suite "JsonRpcProvider":
     check block1.hash != block2.hash
     check block1.number < block2.number
     check block1.timestamp < block2.timestamp
+
+  test "subscribes to new blocks":
+    let oldBlock = !await provider.getBlock(BlockTag.latest)
+    var newBlock: Block
+    let blockHandler = proc(blck: Block) = newBlock = blck
+    let subscription = await provider.subscribe(blockHandler)
+    discard await provider.send("evm_mine")
+    check newBlock.number > oldBlock.number
+    check newBlock.timestamp > oldBlock.timestamp
+    check newBlock.hash != oldBlock.hash
+    await subscription.unsubscribe()


### PR DESCRIPTION
Provider now has a method to subscribe to new blocks. 
Equivalent to [`provider.on("block")`](https://docs.ethers.io/v5/api/providers/provider/#Provider--events) from ethers.js.