### PR TITLE
Release memory when unsubscribe fails

### DIFF
--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -158,9 +158,9 @@ method subscribe*(provider: JsonRpcProvider,
 
 method unsubscribe*(subscription: JsonRpcSubscription) {.async.} =
   let provider = subscription.provider
+  provider.subscriptions.del(subscription.id)
   let client = await provider.client
   discard await client.eth_unsubscribe(subscription.id)
-  provider.subscriptions.del(subscription.id)
 
 # Signer
 


### PR DESCRIPTION
Ensures that even when a call to the ethereum node to
unsubscribe fails, it will release the memory associated
with the subscription, including the subscription handler
closure.