### PR TITLE
Allow types that are equivalent to Confirmable

### DIFF
--- a/testmodule/test.nimble
+++ b/testmodule/test.nimble
@@ -4,6 +4,7 @@ description = "Tests for Nim Ethers library"
 license = "MIT"
 
 requires "asynctest >= 0.3.0 & < 0.4.0"
+requires "questionable >= 0.10.3 & < 0.11.0"
 
 task test, "Run the test suite":
   exec "nimble install -d -y"

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -1,5 +1,6 @@
 import std/json
 import pkg/asynctest
+import pkg/questionable
 import pkg/stint
 import pkg/ethers
 import ./hardhat
@@ -19,7 +20,7 @@ method totalSupply*(erc20: Erc20): UInt256 {.base, contract, view.}
 method balanceOf*(erc20: Erc20, account: Address): UInt256 {.base, contract, view.}
 method allowance*(erc20: Erc20, owner, spender: Address): UInt256 {.base, contract, view.}
 method transfer*(erc20: Erc20, recipient: Address, amount: UInt256) {.base, contract.}
-method mint(token: TestToken, holder: Address, amount: UInt256): Confirmable {.base, contract.}
+method mint(token: TestToken, holder: Address, amount: UInt256): ?TransactionResponse {.base, contract.}
 
 suite "Contracts":
 


### PR DESCRIPTION
Allows `?TransactionResponse`, `Option[TransactionResponse]` etc to be used instead of `Confirmable`.

Figured out how to apply the solution from @Menduist (https://github.com/status-im/nim-ethers/pull/11#discussion_r875539390). Could you review @emizzle?