### PR TITLE
Fix: handle dynamically sized return values

### DIFF
--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -53,9 +53,9 @@ proc createTransaction(contract: Contract,
   Transaction(to: contract.address, data: data)
 
 proc decodeResponse(T: type, bytes: seq[byte]): T =
-  without decoded =? AbiDecoder.decode(bytes, T):
+  without decoded =? AbiDecoder.decode(bytes, (T,)):
     raiseContractError "unable to decode return value as " & $T
-  return decoded
+  return decoded[0]
 
 proc call(contract: Contract,
           function: string,

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -16,6 +16,7 @@ type
     receiver {.indexed.}: Address
     value: UInt256
 
+method name*(erc20: Erc20): string {.base, contract, view.}
 method totalSupply*(erc20: Erc20): UInt256 {.base, contract, view.}
 method balanceOf*(erc20: Erc20, account: Address): UInt256 {.base, contract, view.}
 method allowance*(erc20: Erc20, owner, spender: Address): UInt256 {.base, contract, view.}
@@ -40,6 +41,7 @@ suite "Contracts":
     discard await provider.send("evm_revert", @[snapshot])
 
   test "can call constant functions":
+    check (await token.name()) == "TestToken"
     check (await token.totalSupply()) == 0.u256
     check (await token.balanceOf(accounts[0])) == 0.u256
     check (await token.allowance(accounts[0], accounts[1])) == 0.u256


### PR DESCRIPTION
Dynamically sized return values such as strings and sequences were not decoded as part of a tuple, leading to a difference in byte representation.

Fixes #16