### PR TITLE
Raise EthersError when JSON-RPC fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nim: [1.2.16, 1.4.8, stable]
+        nim: [1.2.16, stable]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Use the [Nimble][2] package manager to add `ethers` to an existing
 project. Add the following to its .nimble file:
 
 ```nim
-requires "ethers >= 0.1.9 & < 0.2.0"
+requires "ethers >= 0.2.0 & < 0.3.0"
 ```
 
 Usage

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -1,4 +1,4 @@
-version = "0.1.9"
+version = "0.2.0"
 author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -74,9 +74,7 @@ suite "Contracts":
               holder: Address,
               amount: UInt256): ?TransactionResponse {.contract.}
     let txResp = await token.mint(accounts[1], 100.u256)
-    # `of` instead of `is` due to v1.4.8 compiler error:
-    # "invalid type: 'type Confirmable' for var"
-    check txResp of (?TransactionResponse)
+    check txResp is (?TransactionResponse)
     check txResp.isSome
 
   test "can call non-constant functions with a Confirmable return type":

--- a/testmodule/testJsonRpcProvider.nim
+++ b/testmodule/testJsonRpcProvider.nim
@@ -241,3 +241,17 @@ suite "JsonRpcProvider":
     wantedConfirms = int.high
     check receipt.hasBeenMined(currentBlock, wantedConfirms)
 
+  test "raises JsonRpcProviderError when something goes wrong":
+    let provider = JsonRpcProvider.new("http://invalid.")
+    expect JsonRpcProviderError:
+      discard await provider.listAccounts()
+    expect JsonRpcProviderError:
+      discard await provider.send("evm_mine")
+    expect JsonRpcProviderError:
+      discard await provider.getBlockNumber()
+    expect JsonRpcProviderError:
+      discard await provider.getBlock(BlockTag.latest)
+    expect JsonRpcProviderError:
+      discard await provider.subscribe(proc(_: Block) {.async.} = discard)
+    expect JsonRpcProviderError:
+      discard await provider.getSigner().sendTransaction(Transaction.example)


### PR DESCRIPTION
When a JSON-RPC call fails, a subtype of`EthersError` is raised.
It used to raise an error type from the `json_rpc` library instead.

Bumping version to 0.2.0, because this is a backwards-incompatible change.
And dropping support for Nim 1.4.x while we're at it.