### PR TITLE
Allow for custom transaction properties

### DIFF
--- a/testmodule/mocks.nim
+++ b/testmodule/mocks.nim
@@ -1,0 +1,20 @@
+import pkg/ethers
+
+type MockSigner* = ref object of Signer
+  provider: Provider
+  address*: Address
+  transactions*: seq[Transaction]
+
+func new*(_: type MockSigner, provider: Provider): MockSigner =
+  MockSigner(provider: provider)
+
+method provider*(signer: MockSigner): Provider =
+  signer.provider
+
+method getAddress*(signer: MockSigner): Future[Address] {.async.} =
+  return signer.address
+
+method sendTransaction*(signer: MockSigner,
+                        transaction: Transaction):
+                       Future[TransactionResponse] {.async.} =
+  signer.transactions.add(transaction)

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -5,6 +5,7 @@ import pkg/stint
 import pkg/ethers
 import ./hardhat
 import ./miner
+import ./mocks
 
 type
 
@@ -111,6 +112,19 @@ suite "Contracts":
     check (await token.connect(provider).balanceOf(accounts[0])) == 50.u256
     check (await token.connect(provider).balanceOf(accounts[1])) == 25.u256
     check (await token.connect(provider).balanceOf(accounts[2])) == 25.u256
+
+  test "takes custom values for nonce, gasprice and gaslimit":
+    let overrides = Transaction(
+      nonce: some 100.u256,
+      gasPrice: some 200.u256,
+      gasLimit: some 300.u256
+    )
+    let signer = MockSigner.new(provider)
+    discard await token.connect(signer).mint(accounts[0], 42.u256, overrides)
+    check signer.transactions.len == 1
+    check signer.transactions[0].nonce == overrides.nonce
+    check signer.transactions[0].gasPrice == overrides.gasPrice
+    check signer.transactions[0].gasLimit == overrides.gasLimit
 
   test "receives events when subscribed":
     var transfers: seq[Transfer]

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -114,7 +114,7 @@ suite "Contracts":
     check (await token.connect(provider).balanceOf(accounts[2])) == 25.u256
 
   test "takes custom values for nonce, gasprice and gaslimit":
-    let overrides = Transaction(
+    let overrides = TransactionOverrides(
       nonce: some 100.u256,
       gasPrice: some 200.u256,
       gasLimit: some 300.u256

--- a/testmodule/testJsonRpcProvider.nim
+++ b/testmodule/testJsonRpcProvider.nim
@@ -60,7 +60,8 @@ suite "JsonRpcProvider":
     let populated = await signer.populateTransaction(transaction)
 
     let txResp = await signer.sendTransaction(populated)
-    check txResp.hash.len == 32 and UInt256.fromHex(txResp.hash.toHex) > 0
+    check txResp.hash.len == 32
+    check UInt256.fromHex("0x" & txResp.hash.toHex) > 0
 
   test "can wait for a transaction to be confirmed":
     let signer = provider.getSigner()


### PR DESCRIPTION
Allows specifying custom transaction properties, such as `nonce` and `gasPrice` when invoking contract calls.

Example:
```nim
let overrides = TransactionOverrides(nonce: some 50.u256)
await writableToken.transfer(address, value, overrides)
```