### PR TITLE
Fix block subscription

### DIFF
--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -10,6 +10,6 @@ proc eth_chainId(): UInt256
 proc eth_sendTransaction(transaction: Transaction): TransactionHash
 proc eth_getTransactionReceipt(hash: TransactionHash): ?TransactionReceipt
 proc eth_sign(account: Address, message: seq[byte]): seq[byte]
-proc eth_subscribe(name: string, filter: ?Filter): JsonNode
+proc eth_subscribe(name: string, filter: Filter): JsonNode
 proc eth_subscribe(name: string): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -10,5 +10,6 @@ proc eth_chainId(): UInt256
 proc eth_sendTransaction(transaction: Transaction): TransactionHash
 proc eth_getTransactionReceipt(hash: TransactionHash): ?TransactionReceipt
 proc eth_sign(account: Address, message: seq[byte]): seq[byte]
-proc eth_subscribe(name: string, filter = Filter.none): JsonNode
+proc eth_subscribe(name: string, filter: ?Filter): JsonNode
+proc eth_subscribe(name: string): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool


### PR DESCRIPTION
Currently subscribing to new Blocks with an external provider leads to an error of 
`{"code":-32602,"message":"too many arguments, want at most 1"}`
That error does not happen with a local ganache or hardhat provider.