### PR TITLE
Rename Provider.sendRawTransaction and cleanup

### DIFF
--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -75,14 +75,16 @@ method getTransactionReceipt*(provider: Provider,
                            Future[?TransactionReceipt] {.base.} =
   doAssert false, "not implemented"
 
+method sendTransaction*(provider: Provider,
+                        rawTransaction: seq[byte]):
+                       Future[TransactionResponse] {.base.} =
+  doAssert false, "not implemented"
+
 method estimateGas*(provider: Provider,
                     transaction: Transaction): Future[UInt256] {.base.} =
   doAssert false, "not implemented"
 
 method getChainId*(provider: Provider): Future[UInt256] {.base.} =
-  doAssert false, "not implemented"
-
-method sendRawTransaction*(provider: Provider, rawTransaction: seq[byte]): Future[TransactionResponse] {.base, async.} =
   doAssert false, "not implemented"
 
 method subscribe*(provider: Provider,

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -151,7 +151,7 @@ method getChainId*(provider: JsonRpcProvider): Future[UInt256] {.async.} =
     except CatchableError:
       return parse(await client.net_version(), UInt256)
 
-method sendRawTransaction*(provider: JsonRpcProvider, rawTransaction: seq[byte]): Future[TransactionResponse] {.async.} =
+method sendTransaction*(provider: JsonRpcProvider, rawTransaction: seq[byte]): Future[TransactionResponse] {.async.} =
   convertError:
     let
       client = await provider.client

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -156,7 +156,7 @@ method sendTransaction*(provider: JsonRpcProvider, rawTransaction: seq[byte]): F
     let
       client = await provider.client
       hash = await client.eth_sendRawTransaction(rawTransaction)
-    
+
     return TransactionResponse(hash: hash, provider: provider)
 
 proc subscribe(provider: JsonRpcProvider,

--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -107,7 +107,7 @@ proc signTransaction*(wallet: Wallet, tx: transaction.Transaction): Future[seq[b
 
 method sendTransaction*(wallet: Wallet, tx: transaction.Transaction): Future[TransactionResponse] {.async.} =
   let rawTX = await signTransaction(wallet, tx)
-  return await wallet.provider.get.sendTransaction(rawTX)
+  return await provider(wallet).sendTransaction(rawTX)
 
 #TODO add functionality to sign messages
 

--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -2,7 +2,6 @@ import eth/keys
 import eth/rlp
 import eth/common
 import eth/common/transaction as ct
-import stew/byteutils
 import ./provider
 import ./transaction
 import ./signer
@@ -12,9 +11,9 @@ export keys
 var rng {.threadvar.}: ref HmacDrbgContext
 
 proc getRng: ref HmacDrbgContext =
-  if rng.isnil:
+  if rng.isNil:
     rng = newRng()
-  return rng
+  rng
 
 type SignableTransaction = common.Transaction
 

--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -108,7 +108,7 @@ proc signTransaction*(wallet: Wallet, tx: transaction.Transaction): Future[seq[b
 
 method sendTransaction*(wallet: Wallet, tx: transaction.Transaction): Future[TransactionResponse] {.async.} =
   let rawTX = await signTransaction(wallet, tx)
-  return await wallet.provider.get.sendRawTransaction(rawTX)
+  return await wallet.provider.get.sendTransaction(rawTX)
 
 #TODO add functionality to sign messages
 

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -101,7 +101,7 @@ suite "Wallet":
       gasLimit: some 21_000.u256,
     )
     let signedTx = await wallet.signTransaction(tx)
-    let txHash = await provider.sendRawTransaction(signedTx)
+    let txHash = await provider.sendTransaction(signedTx)
     check txHash.hash == TransactionHash([167.byte, 105, 79, 222, 144, 123, 214, 138, 4, 199, 124, 181, 35, 236, 79, 93, 84, 4, 85, 172, 40, 50, 189, 187, 219, 6, 172, 98, 243, 196, 93, 64])
   
   test "Can call state-changing function automatically":

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -1,4 +1,5 @@
 import pkg/asynctest
+import pkg/stew/byteutils
 import ../ethers
 
 const pk1 = "9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501"
@@ -28,7 +29,7 @@ suite "Wallet":
 
   test "Private key can start with 0x":
     discard Wallet.new("0x" & pk1)
-  
+
   test "Can create Wallet with provider":
     let provider = JsonRpcProvider.new()
     discard Wallet.new(pk1, provider)
@@ -36,7 +37,7 @@ suite "Wallet":
   test "Can connect Wallet to provider":
     let wallet = Wallet.new(pk1)
     wallet.connect(provider)
-  
+
   test "Can create Random Wallet":
     discard Wallet.createRandom()
 
@@ -47,12 +48,12 @@ suite "Wallet":
     let wallet1 = Wallet.createRandom()
     let wallet2 = Wallet.createRandom()
     check $wallet1.privateKey != $wallet2.privateKey
-  
+
   test "Creates the correct public key and Address from private key":
     let wallet = Wallet.new(pk1)
     check $wallet.publicKey == "5eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b426078dbd48d74af1fd0c72aa1a05147cf17be6b60bdbed6ba19b08ec28445b0ca"
     check $wallet.address == "0x328809bc894f92807417d2dad6b7c998c1afdac6"
-  
+
   test "Can sign manually created transaction":
     let wallet = Wallet.new(pk1)
     let tx = Transaction(
@@ -63,8 +64,8 @@ suite "Wallet":
       gasLimit: some 21_000.u256,
     )
     let signedTx = await wallet.signTransaction(tx)
-    check signedTx == @[248.byte, 99, 128, 132, 59, 154, 202, 0, 130, 82, 8, 148, 50, 136, 9, 188, 137, 79, 146, 128, 116, 23, 210, 218, 214, 183, 201, 152, 193, 175, 218, 198, 128, 128, 27, 160, 74, 233, 178, 76, 186, 114, 16, 59, 179, 10, 30, 145, 192, 22, 121, 111, 194, 191, 45, 70, 210, 183, 92, 168, 2, 17, 250, 224, 51, 124, 60, 3, 160, 94, 60, 129, 206, 153, 68, 160, 127, 24, 182, 81, 66, 161, 132, 124, 91, 114, 249, 147, 200, 231, 194, 141, 93, 67, 96, 255, 54, 162, 254, 208, 73]
-  
+    check signedTx.toHex == "f86380843b9aca0082520894328809bc894f92807417d2dad6b7c998c1afdac680801ba04ae9b24cba72103bb30a1e91c016796fc2bf2d46d2b75ca80211fae0337c3c03a05e3c81ce9944a07f18b65142a1847c5b72f993c8e7c28d5d4360ff36a2fed049"
+
   test "Can sign manually created contract call":
     let wallet = Wallet.new(pk1)
     let tx = Transaction(
@@ -76,7 +77,7 @@ suite "Wallet":
       gasLimit: some 21_000.u256,
     )
     let signedTx = await wallet.signTransaction(tx)
-    check signedTx == @[248.byte, 103, 128, 132, 59, 154, 202, 0, 130, 82, 8, 148, 50, 136, 9, 188, 137, 79, 146, 128, 116, 23, 210, 218, 214, 183, 201, 152, 193, 175, 218, 198, 128, 132, 24, 22, 13, 221, 28, 160, 41, 38, 31, 199, 79, 251, 187, 92, 227, 208, 163, 182, 234, 201, 114, 111, 5, 216, 168, 73, 224, 241, 83, 87, 34, 224, 87, 189, 216, 59, 150, 89, 160, 68, 248, 87, 133, 43, 216, 183, 187, 140, 12, 10, 90, 97, 194, 197, 111, 206, 66, 237, 172, 171, 115, 244, 35, 1, 181, 9, 237, 183, 96, 15, 241]
+    check signedTx.toHex == "f86780843b9aca0082520894328809bc894f92807417d2dad6b7c998c1afdac6808418160ddd1ca029261fc74ffbbb5ce3d0a3b6eac9726f05d8a849e0f1535722e057bdd83b9659a044f857852bd8b7bb8c0c0a5a61c2c56fce42edacab73f42301b509edb7600ff1"
 
   test "Can sign manually created tx with EIP1559":
     let wallet = Wallet.new(pk1)
@@ -89,7 +90,7 @@ suite "Wallet":
       gasLimit: some 21_000.u256
     )
     let signedTx = await wallet.signTransaction(tx)
-    check signedTx == @[2.byte, 248, 108, 130, 122, 105, 128, 132, 59, 154, 202, 0, 132, 119, 53, 148, 0, 130, 82, 8, 148, 50, 136, 9, 188, 137, 79, 146, 128, 116, 23, 210, 218, 214, 183, 201, 152, 193, 175, 218, 198, 128, 128, 192, 1, 160, 22, 41, 41, 252, 91, 76, 178, 134, 237, 76, 214, 48, 209, 114, 209, 221, 116, 125, 173, 79, 251, 235, 65, 59, 3, 127, 33, 22, 143, 79, 227, 102, 160, 98, 185, 49, 193, 252, 85, 2, 138, 225, 253, 245, 52, 37, 100, 48, 12, 174, 37, 23, 145, 215, 133, 160, 239, 211, 28, 8, 132, 5, 166, 81, 231]
+    check signedTx.toHex == "02f86c827a6980843b9aca00847735940082520894328809bc894f92807417d2dad6b7c998c1afdac68080c001a0162929fc5b4cb286ed4cd630d172d1dd747dad4ffbeb413b037f21168f4fe366a062b931c1fc55028ae1fdf5342564300cae251791d785a0efd31c088405a651e7"
 
   test "Can send rawTransaction":
     let wallet = Wallet.new(pk_with_funds)
@@ -103,7 +104,7 @@ suite "Wallet":
     let signedTx = await wallet.signTransaction(tx)
     let txHash = await provider.sendTransaction(signedTx)
     check txHash.hash == TransactionHash([167.byte, 105, 79, 222, 144, 123, 214, 138, 4, 199, 124, 181, 35, 236, 79, 93, 84, 4, 85, 172, 40, 50, 189, 187, 219, 6, 172, 98, 243, 196, 93, 64])
-  
+
   test "Can call state-changing function automatically":
     #TODO add actual token contract, not random address. Should work regardless
     let wallet = Wallet.new(pk_with_funds, provider)


### PR DESCRIPTION
Renames `Provider.sendRawTransaction(bytes)` to `Provider.sendTransaction(bytes)` to be consistent with [ethers.js](https://docs.ethers.io/v5/api/providers/provider/#Provider-sendTransaction)

Does some cleanup around the wallet as well.