### PR TITLE
[feat] support distinct types

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Use the [Nimble][2] package manager to add `ethers` to an existing
 project. Add the following to its .nimble file:
 
 ```nim
-requires "ethers >= 0.2.1 & < 0.3.0"
+requires "ethers >= 0.2.2 & < 0.3.0"
 ```
 
 Usage

--- a/Readme.md
+++ b/Readme.md
@@ -119,20 +119,6 @@ type
   MyEvent = object of Event
     a {.indexed.}: DistinctAlias
     b: DistinctAlias # also allowed for non-indexed fields
-
-## The below funcs generally need to be included for ABI
-## encoding/decoding purposes when implementing distinct types.
-
-func toArray(value: DistinctAlias): array[32, byte] =
-  array[32, byte](value)
-
-func encode*(encoder: var AbiEncoder, value: DistinctAlias) =
-  encoder.write(value.toArray)
-
-func decode*(decoder: var AbiDecoder,
-             T: type DistinctAlias): ?!T =
-  let d = ?decoder.read(type array[32, byte])
-  success DistinctAlias(d)
 ```
 
 You can now subscribe to Transfer events by calling `subscribe` on the contract

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -4,7 +4,7 @@ description = "library for interacting with Ethereum"
 license = "MIT"
 
 requires "chronos >= 3.0.0 & < 4.0.0"
-requires "contractabi >= 0.4.5 & < 0.5.0"
+requires "contractabi#distinct"
 requires "questionable >= 0.10.2 & < 0.11.0"
 requires "upraises >= 0.1.0 & < 0.2.0"
 requires "json_rpc"

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -1,4 +1,4 @@
-version = "0.2.1"
+version = "0.2.2"
 author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -1,10 +1,10 @@
-version = "0.2.2"
+version = "0.2.3"
 author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"
 
 requires "chronos >= 3.0.0 & < 4.0.0"
-requires "contractabi#distinct"
+requires "contractabi >= 0.4.6 & < 0.5.0"
 requires "questionable >= 0.10.2 & < 0.11.0"
 requires "upraises >= 0.1.0 & < 0.2.0"
 requires "json_rpc"

--- a/ethers/events.nim
+++ b/ethers/events.nim
@@ -1,4 +1,5 @@
 import std/macros
+import std/typetraits
 import pkg/contractabi
 import ./basics
 import ./provider
@@ -40,7 +41,10 @@ func decode*[E: Event](_: type E, data: seq[byte], topics: seq[Topic]): ?!E =
     if field.hasCustomPragma(indexed):
       if i >= topics.len:
         return failure "indexed event parameter not found"
-      if typeof(field) is ValueType or typeof(field) is SmallByteArray:
-        field = ?AbiDecoder.decode(@(topics[i]), typeof(field))
+      if typeof(field) is ValueType or
+         typeof(field) is SmallByteArray or
+         typeof(field).distinctBase is ValueType or
+         typeof(field).distinctBase is SmallByteArray:
+          field = ?AbiDecoder.decode(@(topics[i]), typeof(field))
       inc i
   success event

--- a/ethers/events.nim
+++ b/ethers/events.nim
@@ -35,11 +35,15 @@ func decode*[E: Event](decoder: var AbiDecoder, _: type E): ?!E =
   success event
 
 func isSupported(T: type): bool =
-  var supported = T is ValueType or
-                  T is SmallByteArray
-  when compiles (T.distinctBase):
-    supported = supported or T.distinctBase is ValueType or
-                             T.distinctBase is SmallByteArray
+  var supported = false
+  # nim 1.2.x fails distinctBase checks on non-distinct types at compile time,
+  # so we must separate with `when`
+  when T is distinct:
+    supported = T.distinctBase is ValueType or
+                T.distinctBase is SmallByteArray
+  else:
+    supported = T is ValueType or
+                T is SmallByteArray
   return supported
 
 func decode*[E: Event](_: type E, data: seq[byte], topics: seq[Topic]): ?!E =

--- a/testmodule/testEvents.nim
+++ b/testmodule/testEvents.nim
@@ -5,23 +5,11 @@ import ./examples
 
 ## Define outside the scope of the suite to allow for exporting
 ## To use custom distinct types, these procs will generally need
-## to be defined in the application code anyway, to support ABI
-## encoding/decoding
+## to be defined in the application code anyway
 type
   DistinctAlias = distinct array[32, byte]
 
 proc `==`*(x, y: DistinctAlias): bool {.borrow.}
-
-func toArray(value: DistinctAlias): array[32, byte] =
-  array[32, byte](value)
-
-func encode*(encoder: var AbiEncoder, value: DistinctAlias) =
-  encoder.write(value.toArray)
-
-func decode*(decoder: var AbiDecoder,
-             T: type DistinctAlias): ?!T =
-  let d = ?decoder.read(type array[32, byte])
-  success DistinctAlias(d)
 
 suite "Events":
 
@@ -74,9 +62,6 @@ suite "Events":
     IndexedWithDistinctType(
       a: DistinctAlias(array[32, byte].example)
     )
-
-  func encode(_: type AbiEncoder, value: DistinctAlias): seq[byte] =
-    @(value.toArray)
 
   func encode[T](_: type Topic, value: T): Topic =
     let encoded = AbiEncoder.encode(value)


### PR DESCRIPTION
Add support for indexed (and non-indexed) Event fields types that are distinct `ValueType` or `SmallByteArray`. For example,
```nim
type
  DistinctAlias = distinct array[32, byte]
  MyEvent = object of Event
    a {.indexed.}: DistinctAlias
    b: DistinctAlias # also allowed for non-indexed fields
```

### Note
1. ~~This is branched off `0.2.0`, commit 16a3d25419ed849cf6791e6537ad5b3736148376, to retain compatibility with `nim-codex`. We should consider rectifying support for nim-codex. See https://github.com/status-im/nim-codex/issues/220 for more info.~~ 
EDIT: Now branched off main and will re-implement support for `nim-eth` in `nim-codex`.
2. ~~Depends on https://github.com/status-im/nim-contract-abi/pull/5, which should likely be merged first, then this PR can be updated so that it does not depend on a branch of `nim-contract-abi`.~~