### PR TITLE
Change `reverts` api

### DIFF
--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -10,6 +10,7 @@ push: {.upraises: [].}
 
 type
   Provider* = ref object of RootObj
+  ProviderError* = object of EthersError
   Subscription* = ref object of RootObj
   Filter* = object
     address*: Address

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -25,7 +25,7 @@ type
   JsonRpcSigner* = ref object of Signer
     provider: JsonRpcProvider
     address: ?Address
-  JsonRpcProviderError* = object of EthersError
+  JsonRpcProviderError* = object of ProviderError
   SubscriptionHandler = proc(id, arguments: JsonNode): Future[void] {.gcsafe, upraises:[].}
 
 proc raiseProviderError(message: string) {.upraises: [JsonRpcProviderError].} =

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -28,7 +28,12 @@ type
   JsonRpcProviderError* = object of EthersError
   SubscriptionHandler = proc(id, arguments: JsonNode): Future[void] {.gcsafe, upraises:[].}
 
-template raiseProviderError(message: string) =
+proc raiseProviderError(message: string) {.upraises: [JsonRpcProviderError].} =
+  var message = message
+  try:
+    message = parseJson(message){"message"}.getStr
+  except Exception:
+    discard
   raise newException(JsonRpcProviderError, message)
 
 template convertError(body) =

--- a/ethers/testing.nim
+++ b/ethers/testing.nim
@@ -1,8 +1,7 @@
-import std/json
 import std/strutils
 import pkg/ethers
 
-proc revertReason*(e: ref JsonRpcProviderError): string =
+proc revertReason*(e: ref ProviderError): string =
   try:
     var msg = e.msg
     const revertPrefixes = @[
@@ -26,7 +25,7 @@ proc reverts*[T](call: Future[T]): Future[bool] {.async.} =
     else:
       discard await call # TODO test this
     return false
-  except JsonRpcProviderError:
+  except ProviderError:
     return true
 
 proc reverts*[T](call: Future[T], reason: string): Future[bool] {.async.} =
@@ -36,5 +35,5 @@ proc reverts*[T](call: Future[T], reason: string): Future[bool] {.async.} =
     else:
       discard await call # TODO test this
     return false
-  except JsonRpcProviderError as error:
+  except ProviderError as error:
     return reason == error.revertReason

--- a/ethers/testing.nim
+++ b/ethers/testing.nim
@@ -4,8 +4,7 @@ import pkg/ethers
 
 proc revertReason*(e: ref JsonRpcProviderError): string =
   try:
-    let json = parseJson(e.msg)
-    var msg = json{"message"}.getStr
+    var msg = e.msg
     const revertPrefixes = @[
       # hardhat
       "Error: VM Exception while processing transaction: reverted with " &
@@ -28,7 +27,7 @@ proc reverts*[T](call: Future[T]): Future[bool] {.async.} =
       discard await call # TODO test this
     return false
   except JsonRpcProviderError:
-    return true # TODO: check that error started with revert prefix
+    return true
 
 proc reverts*[T](call: Future[T], reason: string): Future[bool] {.async.} =
   try:

--- a/ethers/testing.nim
+++ b/ethers/testing.nim
@@ -1,5 +1,6 @@
 import std/strutils
-import pkg/ethers
+import std/json
+import ./provider
 
 proc revertReason*(e: ref ProviderError): string =
   try:

--- a/ethers/testing.nim
+++ b/ethers/testing.nim
@@ -1,23 +1,19 @@
 import std/strutils
-import std/json
 import ./provider
 
 proc revertReason*(e: ref ProviderError): string =
-  try:
-    var msg = e.msg
-    const revertPrefixes = @[
-      # hardhat
-      "Error: VM Exception while processing transaction: reverted with " &
-      "reason string ",
-      # ganache
-      "VM Exception while processing transaction: revert "
-    ]
-    for prefix in revertPrefixes.items:
-      msg = msg.replace(prefix)
-    msg = msg.replace("\'")
-    return msg
-  except JsonParsingError:
-    return ""
+  var msg = e.msg
+  const revertPrefixes = @[
+    # hardhat
+    "Error: VM Exception while processing transaction: reverted with " &
+    "reason string ",
+    # ganache
+    "VM Exception while processing transaction: revert "
+  ]
+  for prefix in revertPrefixes.items:
+    msg = msg.replace(prefix)
+  msg = msg.replace("\'")
+  return msg
 
 proc reverts*[T](call: Future[T]): Future[bool] {.async.} =
   try:

--- a/ethers/testing.nim
+++ b/ethers/testing.nim
@@ -23,7 +23,7 @@ proc reverts*[T](call: Future[T]): Future[bool] {.async.} =
     when T is void:
       await call
     else:
-      discard await call # TODO test this
+      discard await call
     return false
   except ProviderError:
     return true
@@ -33,7 +33,7 @@ proc reverts*[T](call: Future[T], reason: string): Future[bool] {.async.} =
     when T is void:
       await call
     else:
-      discard await call # TODO test this
+      discard await call
     return false
   except ProviderError as error:
     return reason == error.revertReason

--- a/testmodule/test.nimble
+++ b/testmodule/test.nimble
@@ -3,7 +3,7 @@ author = "Nim Ethers Authors"
 description = "Tests for Nim Ethers library"
 license = "MIT"
 
-requires "asynctest >= 0.3.0 & < 0.4.0"
+requires "asynctest >= 0.3.2 & < 0.4.0"
 requires "questionable >= 0.10.3 & < 0.11.0"
 
 task test, "Run the test suite":

--- a/testmodule/testTesting.nim
+++ b/testmodule/testTesting.nim
@@ -1,4 +1,3 @@
-import std/json
 import std/strformat
 import pkg/asynctest
 import pkg/chronos
@@ -9,10 +8,8 @@ import ./hardhat
 suite "Testing helpers":
 
   let revertReason = "revert reason"
-  let rpcResponse = %* {
-    "message": "Error: VM Exception while processing transaction: " &
-               fmt"reverted with reason string '{revertReason}'"
-  }
+  let rpcResponse = "Error: VM Exception while processing transaction: " &
+                    fmt"reverted with reason string '{revertReason}'"
 
   test "checks that call reverts":
     proc call() {.async.} =
@@ -58,9 +55,8 @@ suite "Testing helpers":
 
   test "revert handles non-standard revert prefix":
     let nonStdMsg = fmt"Provider VM Exception: reverted with {revertReason}"
-    let nonStdRpcResponse = %* { "message": nonStdMsg }
     proc call() {.async.} =
-      raise newException(JsonRpcProviderError, $nonStdRpcResponse)
+      raise newException(JsonRpcProviderError, nonStdMsg)
 
     check await call().reverts(nonStdMsg)
 

--- a/testmodule/testTesting.nim
+++ b/testmodule/testTesting.nim
@@ -13,13 +13,13 @@ suite "Testing helpers":
 
   test "checks that call reverts":
     proc call() {.async.} =
-      raise newException(JsonRpcProviderError, $rpcResponse)
+      raise newException(ProviderError, $rpcResponse)
 
     check await call().reverts()
 
   test "checks reason for revert":
     proc call() {.async.} =
-      raise newException(JsonRpcProviderError, $rpcResponse)
+      raise newException(ProviderError, $rpcResponse)
 
     check await call().reverts(revertReason)
 
@@ -28,14 +28,14 @@ suite "Testing helpers":
 
     check not await call().reverts()
 
-  test "reverts only checks JsonRpcProviderErrors":
+  test "reverts only checks ProviderErrors":
     proc call() {.async.} =
       raise newException(ContractError, "test")
 
     expect ContractError:
       check await call().reverts()
 
-  test "reverts with reason only checks JsonRpcProviderErrors":
+  test "reverts with reason only checks ProviderErrors":
     proc call() {.async.} =
       raise newException(ContractError, "test")
 
@@ -49,14 +49,14 @@ suite "Testing helpers":
 
   test "reverts is false when the revert reason doesn't match":
     proc call() {.async.} =
-      raise newException(JsonRpcProviderError, "other reason")
+      raise newException(ProviderError, "other reason")
 
     check not await call().reverts(revertReason)
 
   test "revert handles non-standard revert prefix":
     let nonStdMsg = fmt"Provider VM Exception: reverted with {revertReason}"
     proc call() {.async.} =
-      raise newException(JsonRpcProviderError, nonStdMsg)
+      raise newException(ProviderError, nonStdMsg)
 
     check await call().reverts(nonStdMsg)
 

--- a/testmodule/testTesting.nim
+++ b/testmodule/testTesting.nim
@@ -60,6 +60,11 @@ suite "Testing helpers":
 
     check await call().reverts(nonStdMsg)
 
+  test "works with functions that return a value":
+    proc call(): Future[int] {.async.} = return 42
+    check not await call().reverts()
+    check not await call().reverts("some reason")
+
 type
   TestHelpers* = ref object of Contract
 


### PR DESCRIPTION
Changes the API introduced in #33 to allow for post-fix use of the `reverts` function. Example:

```nim
check await ethCall().reverts("some reason")
```

Changes:
- Removes `doesNot*` functions; you can use `check not` instead
- Removes implicit `waitFor` calls; `reverts()` returns a Future that you can await
- Should work for all providers instead of just the JsonRpcProvider
- Strips the JSON wrapper around error messages in the JsonRpcProvider
