### PR TITLE
Use "pending" blocktag by default, instead of "latest"

### DIFF
--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -80,19 +80,17 @@ proc decodeResponse(T: type, multiple: static bool, bytes: seq[byte]): T =
 
 proc call(contract: Contract,
           function: string,
-          parameters: tuple,
-          blockTag = BlockTag.latest) {.async.} =
+          parameters: tuple) {.async.} =
   let transaction = createTransaction(contract, function, parameters)
-  discard await contract.provider.call(transaction, blockTag)
+  discard await contract.provider.call(transaction)
 
 proc call(contract: Contract,
           function: string,
           parameters: tuple,
           ReturnType: type,
-          returnMultiple: static bool,
-          blockTag = BlockTag.latest): Future[ReturnType] {.async.} =
+          returnMultiple: static bool): Future[ReturnType] {.async.} =
   let transaction = createTransaction(contract, function, parameters)
-  let response = await contract.provider.call(transaction, blockTag)
+  let response = await contract.provider.call(transaction)
   return decodeResponse(ReturnType, returnMultiple, response)
 
 proc send(contract: Contract,

--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -59,7 +59,7 @@ method getBlock*(provider: Provider, tag: BlockTag): Future[?Block] {.base.} =
 
 method call*(provider: Provider,
              tx: Transaction,
-             blockTag = BlockTag.latest): Future[seq[byte]] {.base.} =
+             blockTag = BlockTag.pending): Future[seq[byte]] {.base.} =
   doAssert false, "not implemented"
 
 method getGasPrice*(provider: Provider): Future[UInt256] {.base.} =
@@ -67,7 +67,7 @@ method getGasPrice*(provider: Provider): Future[UInt256] {.base.} =
 
 method getTransactionCount*(provider: Provider,
                             address: Address,
-                            blockTag = BlockTag.latest):
+                            blockTag = BlockTag.pending):
                            Future[UInt256] {.base.} =
   doAssert false, "not implemented"
 

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -133,7 +133,7 @@ method getGasPrice*(provider: JsonRpcProvider): Future[UInt256] {.async.} =
 
 method getTransactionCount*(provider: JsonRpcProvider,
                             address: Address,
-                            blockTag = BlockTag.latest):
+                            blockTag = BlockTag.pending):
                            Future[UInt256] {.async.} =
   convertError:
     let client = await provider.client

--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -27,7 +27,7 @@ method getGasPrice*(signer: Signer): Future[UInt256] {.base.} =
   signer.provider.getGasPrice()
 
 method getTransactionCount*(signer: Signer,
-                            blockTag = BlockTag.latest):
+                            blockTag = BlockTag.pending):
                            Future[UInt256] {.base, async.} =
   let address = await signer.getAddress()
   return await signer.provider.getTransactionCount(address, blockTag)
@@ -55,7 +55,7 @@ method populateTransaction*(signer: Signer,
   if transaction.sender.isNone:
     populated.sender = some(await signer.getAddress())
   if transaction.nonce.isNone:
-    populated.nonce = some(await signer.getTransactionCount(BlockTag.pending))
+    populated.nonce = some(await signer.getTransactionCount())
   if transaction.chainId.isNone:
     populated.chainId = some(await signer.getChainId())
   if transaction.gasPrice.isNone and (transaction.maxFee.isNone or transaction.maxPriorityFee.isNone):

--- a/testmodule/testJsonRpcSigner.nim
+++ b/testmodule/testJsonRpcSigner.nim
@@ -27,7 +27,7 @@ suite "JsonRpcSigner":
 
   test "can retrieve transaction count":
     let signer = provider.getSigner(accounts[9])
-    let count = await signer.getTransactionCount(BlockTag.pending)
+    let count = await signer.getTransactionCount()
     check count == 0.u256
 
   test "can estimate gas cost of a transaction":
@@ -51,7 +51,7 @@ suite "JsonRpcSigner":
     let populated = await signer.populateTransaction(transaction)
     check !populated.sender == await signer.getAddress()
     check !populated.gasPrice == await signer.getGasPrice()
-    check !populated.nonce == await signer.getTransactionCount(BlockTag.pending)
+    check !populated.nonce == await signer.getTransactionCount()
     check !populated.gasLimit == await signer.estimateGas(transaction)
     check !populated.chainId == await signer.getChainId()
 


### PR DESCRIPTION
This allows better simulation of the effects of sending a transaction before actually sending it. Especially when the block timestamp is used in the transaction.