### PR TITLE
fix: eth_call use signers address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nim: [1.2.16, stable]
+        nim: [1.6.12, stable]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -3,6 +3,7 @@ author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"
 
+requires "nim >= 1.6.0"
 requires "chronos >= 3.0.0 & < 4.0.0"
 requires "contractabi >= 0.4.6 & < 0.5.0"
 requires "questionable >= 0.10.2 & < 0.11.0"

--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -93,7 +93,11 @@ proc call(contract: Contract,
           function: string,
           parameters: tuple,
           overrides = TransactionOverrides()) {.async.} =
-  let transaction = createTransaction(contract, function, parameters, overrides)
+  var transaction = createTransaction(contract, function, parameters, overrides)
+
+  if signer =? contract.signer and transaction.sender.isNone:
+    transaction.sender = some(await signer.getAddress())
+
   discard await contract.provider.call(transaction, overrides)
 
 proc call(contract: Contract,
@@ -102,7 +106,11 @@ proc call(contract: Contract,
           ReturnType: type,
           returnMultiple: static bool,
           overrides = TransactionOverrides()): Future[ReturnType] {.async.} =
-  let transaction = createTransaction(contract, function, parameters, overrides)
+  var transaction = createTransaction(contract, function, parameters, overrides)
+
+  if signer =? contract.signer and transaction.sender.isNone:
+    transaction.sender = some(await signer.getAddress())
+
   let response = await contract.provider.call(transaction, overrides)
   return decodeResponse(ReturnType, returnMultiple, response)
 

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -13,6 +13,7 @@ type
   TestToken = ref object of Erc20Token
 
 method mint(token: TestToken, holder: Address, amount: UInt256): ?TransactionResponse {.base, contract.}
+method myBalance(token: TestToken): UInt256 {.contract, view.}
 
 suite "Contracts":
 
@@ -42,6 +43,13 @@ suite "Contracts":
     discard await token.mint(accounts[1], 100.u256)
     check (await token.totalSupply()) == 100.u256
     check (await token.balanceOf(accounts[1])) == 100.u256
+
+  test "can call constant functions with a signer and the account is used for the call":
+    let signer0 = provider.getSigner(accounts[0])
+    let signer1 = provider.getSigner(accounts[1])
+    discard await token.connect(signer0).mint(accounts[1], 100.u256)
+    check (await token.connect(signer0).myBalance()) == 0.u256
+    check (await token.connect(signer1).myBalance()) == 100.u256
 
   test "can call non-constant functions without a signer":
     discard await token.mint(accounts[1], 100.u256)

--- a/testnode/contracts/TestToken.sol
+++ b/testnode/contracts/TestToken.sol
@@ -17,4 +17,8 @@ contract TestToken is ERC20 {
   function burn(address holder, uint amount) public {
     _burn(holder, amount);
   }
+
+  function myBalance() public view returns (uint256)  {
+    return balanceOf(msg.sender);
+  }
 }


### PR DESCRIPTION
Fixes issue where `msg.sender` for `eth_call` was not correctly set from the connected signer.